### PR TITLE
アバターID参考用のサイトのURLを置換

### DIFF
--- a/docs/en/commands.md
+++ b/docs/en/commands.md
@@ -102,7 +102,7 @@ Actual word to run command is configurable in commands editor (commands.json)
 |  party_message  |  party_message [Message]  |  Send message to party  |
 |  avatar  |  avatar [ID] (Color)  |  Set avatar<br>Information of color setting is [here](config.md#Colors)  |
 |  status  |  status [Message]  |  Set status  |
-|  banner  |  banner [Banner ID] [Banner color]  |  Set banner<br>Banner ids is [here](https://fnitems.pdfweb.tk/banner)  |
+|  banner  |  banner [Banner ID] [Banner color]  |  Set banner<br>Banner ids is [here](https://fnitems.hyperserver.xyz/banners)  |
 |  level  |  level [Number]  |  Set level  |
 |  privacy  |  privacy [public, friends_allow_friends_of_friends, friends, private_allow_friends_of_friends, private]  |  Set party's privacy  |
 |  voice_chat  |  voice_chat [true/false]  |  Enable/Disable voice chat. This won't affect to members which joined before run this command  |

--- a/docs/en/config.md
+++ b/docs/en/config.md
@@ -83,7 +83,7 @@ Usually please use web config editor to change configs
 | --- | --- |
 |  Avatar ID (avatar_id)  |  Avatar ID<br>Use `{bot}` to change avatar to bot's outfit (There are many unsupported outfits)  |
 |  Avatar color (avatar_color)  |  Avatar color<br>For more information see [here](#Color)  |
-|  Banner ID (banner_id)  |  Banner ID><br>List of ids are [here](https://fnitems.pdfweb.tk/banner)  |
+|  Banner ID (banner_id)  |  Banner ID><br>List of ids are [here](https://fnitems.hyperserver.xyz/banners)  |
 |  Banner color (banner_color)  |  Banner color  |
 |  Level (level)  |  Level  |
 |  Platform (platform)  |  Platform  |

--- a/docs/es/commands.md
+++ b/docs/es/commands.md
@@ -102,7 +102,7 @@ Valores en [] son requeridos, valores en () son opcionales
 |  party_Mensaje  |  party_Mensaje [Mensaje]  |  Envía un mensaje a la sala  |
 |  avatar  |  avatar [ID] (Color)  |  Configura el avatar<br>Puedes ver los colores utilizables [aquí](config.md#Color)  |
 |  status  |  status [Mensaje]  |  Configura el status  |
-|  banner  |  banner [ID de banner] [Color del banner]  |  Configura el banner<br>Los ids puedes encontrarlos [aquí](https://fnitems.pdfweb.tk/banner)  |
+|  banner  |  banner [ID de banner] [Color del banner]  |  Configura el banner<br>Los ids puedes encontrarlos [aquí](https://fnitems.hyperserver.xyz/banners)  |
 |  level  |  level [Number]  |  Configura el nivel  |
 |  privacy  |  privacy [public, friends_allow_friends_of_friends, friends, private_allow_friends_of_friends, private]  |  Configura la privacidad de la sala  |
 |  voice_chat  |  voice_chat [true/false]  |  Activa/desactiva el chat de voz de la sala. Esto no afecta a miembros que se unieron antes de unirse a la sala  |

--- a/docs/es/config.md
+++ b/docs/es/config.md
@@ -83,7 +83,7 @@ Utiliza el editor de configuración web para cambiar configuraciones
 | --- | --- |
 |  ID de avatar (avatar_id)  |  ID de avatar<br>Usa la variable `{bot}` para cambiar el avatar al de la skin del bot (Existen skins no soportadas por esto)  |
 |  Color del avatar (avatar_color)  |  Color del avatar<br>Para más información revisa [aquí](#Color)  |
-|  ID de banner (banner_id)  |  ID del banner><br>Puedes ver una lista de ellos [aquí](https://fnitems.pdfweb.tk/banner)  |
+|  ID de banner (banner_id)  |  ID del banner><br>Puedes ver una lista de ellos [aquí](https://fnitems.hyperserver.xyz/banners)  |
 |  Color del banner (banner_color)  |  Color del banner  |
 |  Nivel (level)  |  Nivel  |
 |  Plataforma (platform)  |  Plataforma  |

--- a/docs/ja/commands.md
+++ b/docs/ja/commands.md
@@ -102,7 +102,7 @@
 |  party_message  |  party_message [メッセージ]  |  パーティーにメッセージを送信する  |
 |  avatar  |  avatar [ID] (色)  |  アバターを設定する<br>色の設定方法は[こちら](config.md#色)  |
 |  status  |  status [メッセージ]  |  ステータスを設定する  |
-|  banner  |  banner [バナーID] [バナーの色]  |  バナーを設定する<br>バナーIDは[こちら](https://fnitems.pdfweb.tk/banner)  |
+|  banner  |  banner [バナーID] [バナーの色]  |  バナーを設定する<br>バナーIDは[こちら](https://fnitems.hyperserver.xyz/banners)  |
 |  level  |  level [数値]  |  レベルを設定する  |
 |  privacy  |  privacy [public, friends_allow_friends_of_friends, friends, private_allow_friends_of_friends, private]  |  パーティーのプライバシーを設定する  |
 |  voice_chat  |  voice_chat [true/false]  |  ボイスチャットを有効/無効化する。このコマンドを実行する前にいたメンバーには効果がない  |

--- a/docs/ja/commands.md
+++ b/docs/ja/commands.md
@@ -104,6 +104,7 @@
 |  status  |  status [メッセージ]  |  ステータスを設定する  |
 |  banner  |  banner [バナーID] [バナーの色]  |  バナーを設定する<br>バナーIDは[こちら](https://fnitems.hyperserver.xyz/banners)  |
 |  level  |  level [数値]  |  レベルを設定する  |
+|  battlepass  |  battlepass [数値]  |  ティアを設定する  |
 |  privacy  |  privacy [public, friends_allow_friends_of_friends, friends, private_allow_friends_of_friends, private]  |  パーティーのプライバシーを設定する  |
 |  voice_chat  |  voice_chat [true/false]  |  ボイスチャットを有効/無効化する。このコマンドを実行する前にいたメンバーには効果がない  |
 |  promote  |  promote [名前/ID]  |  ユーザーにパーティーリーダーを譲渡する  |
@@ -159,6 +160,7 @@
 |  random_item |  random_item  |  ランダムなアイテムに変更する  |
 |  playlist_id  |  playlist_id [ID]  |  IDでプレイリストを検索し、そのプレイリストに変更する  |
 |  playlist  |  playlist [名前]  |  プレイリストを検索し、そのプレイリストに変更する  |
+|  island_code  |  island_code [島コード]  |  モードをその島に変更する  |
 |  set  |  set [名前]  |  セット名でアイテムを検索し、そのアイテムに変更する  |
 |  set_style  |  set_style [outfit/backpack/pickaxe]  |  現在使用しているアイテムのスタイル一覧を表示し、指定したスタイルに設定する  |
 |  add_style  |  add_style [outfit/backpack/pickaxe]  |  現在使用しているアイテムのスタイル一覧を表示し、指定したスタイルを現在のスタイルに統合する<br>例: ステージ1のスタイルにadd_styleで青を追加  |

--- a/docs/ja/config.md
+++ b/docs/ja/config.md
@@ -86,6 +86,7 @@
 |  バナーのID (banner_id)  |  バナーのID<br>一覧は[こちら](https://fnitems.hyperserver.xyz/banners)  |
 |  バナーの色 (banner_color)  |  バナーの色  |
 |  レベル (level)  |  レベル  |
+|  ティア (tier)  |  ティア  |
 |  プラットフォーム (platform)  |  プラットフォーム  |
 |  NGプラットフォーム (ng_platforms)  |  NGに指定するプラットフォーム  |
 |  NGプラットフォームの適用先 (ng_platform_for)  |  NGプラットフォームを適用するユーザーの種類  |

--- a/docs/ja/config.md
+++ b/docs/ja/config.md
@@ -83,7 +83,7 @@
 | --- | --- |
 |  アバターID (avatar_id)  |  アバターのID<br>`{bot}`とすることで現在使用しているコスチュームのアイコンになる(非対応の物も多い)  |
 |  アバターの色 (avatar_color)  |  アバターの色<br>詳細は[こちら](#色)  |
-|  バナーのID (banner_id)  |  バナーのID<br>一覧は[こちら](https://fnitems.pdfweb.tk/banner)  |
+|  バナーのID (banner_id)  |  バナーのID<br>一覧は[こちら](https://fnitems.hyperserver.xyz/banners)  |
 |  バナーの色 (banner_color)  |  バナーの色  |
 |  レベル (level)  |  レベル  |
 |  プラットフォーム (platform)  |  プラットフォーム  |


### PR DESCRIPTION
アバターIDの参考に貼られていたURLを https://fnitems.pdfweb.tk/banner から https://fnitems.hyperserver.xyz/banners に置き換えました