### PR TITLE
Fixed ModuleNotFoundError in replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,5 @@
 language = "python3"
 run = "python3 index.py"
+
+[packager]
+ignoredPackages=["fortnitepy"]

--- a/modules/auto_updater.py
+++ b/modules/auto_updater.py
@@ -114,6 +114,7 @@ class Updater:
             'RUN.bat': []
         }
         self.repl_updates = {
+            '.replit': [],
             'pyproject.toml': []
         }
 

--- a/modules/auto_updater.py
+++ b/modules/auto_updater.py
@@ -114,7 +114,6 @@ class Updater:
             'RUN.bat': []
         }
         self.repl_updates = {
-            '.replit': [],
             'pyproject.toml': []
         }
 


### PR DESCRIPTION
replitで起動時に、ModuleNotFoundErrorが発生してしまう問題を修正しました。
auto_updaterのtagについては、よく分からなかったので確認していただけると幸いです。