### PR TITLE
Update config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -277,7 +277,7 @@
     "lang": "en",
     "search_lang": "en",
     "sub_search_lang": "en",
-    "api": "Fortnite-API",
+    "api": "BenBot",
     "api_key": "",
     "discord_log": "",
     "omit_over2000": false,


### PR DESCRIPTION
Fortnite-APIからreplitのipがbanされたため、デフォルトのapiをBenBotに変更しました。
banについてのソース: https://discord.com/channels/621452110558527502/640614501535842315/954050519305973800