### PR TITLE
Add `authorization_code` support

### DIFF
--- a/index.py
+++ b/index.py
@@ -93,7 +93,8 @@ if __name__ == '__main__':
         loop=loop,
         dev='-dev' in sys.argv,
         use_device_code='-use-device-code' in sys.argv,
-        use_device_auth='-use-device-auth' in sys.argv
+        use_device_auth='-use-device-auth' in sys.argv,
+        use_authorization_code='-use-authorization-code' in sys.argv
     )
     bot.setup()
     loop.run_until_complete(bot.start())

--- a/lang/en.json
+++ b/lang/en.json
@@ -82,6 +82,7 @@
         "updating": "Checking item data updates...",
         "booting": "Booting bot...",
         "session_id": "Open\nhttps://www.epicgames.com/id/login?redirectUrl=https://www.epicgames.com/id/api/redirect&prompt=login\nAnd login to '{0}' and copy paste text",
+        "authorization_code": "Open\nhttps://www.epicgames.com/id/login?redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fid%2Fapi%2Fredirect%3FclientId%3D3446cd72694c4a4485d81b77adbb2141%26responseType%3Dcode&prompt=login\nAnd login to '{0}' and copy paste text",
         "confirm_authorization": "Open\n{0}\nAnd login to '{1}' and press 'Confirm' button",
         "account_incorrect": "This account ({0}) is not '{1}'",
         "device_auth_error": "device_auth of '{0}' is invalid. Reboot bot and do authorization again",

--- a/lang/es.json
+++ b/lang/es.json
@@ -82,6 +82,7 @@
         "updating": "Revisando actualizaciones de ítems...",
         "booting": "Iniciando bot...",
         "session_id": "Abre\nhttps://www.epicgames.com/id/login?redirectUrl=https://www.epicgames.com/id/api/redirect&prompt=login\nE inicia sesión en '{0}' y copiar pegar texto",
+        "authorization_code": "Abre\nhttps://www.epicgames.com/id/login?redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fid%2Fapi%2Fredirect%3FclientId%3D3446cd72694c4a4485d81b77adbb2141%26responseType%3Dcode&prompt=login\nE inicia sesión en '{0}' y copiar pegar texto",
         "confirm_authorization": "Abre\n{0}\nE inicia sesión en '{1}' y presiona el botón 'Confirmar'",
         "account_incorrect": "Esta cuenta ({0}) no es '{1}'",
         "device_auth_error": "device_auth de '{0}' es inválida. Reinicia el bot y haz la autorización de nuevo",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -82,6 +82,7 @@
         "updating": "アイテムデータの更新を確認中...",
         "booting": "ボットを起動中...",
         "session_id": "https://www.epicgames.com/id/login?redirectUrl=https://www.epicgames.com/id/api/redirect&prompt=login\nを開いて '{0}' にログインし、ログイン後に出てきたテキストを貼り付けてください",
+        "authorization_code": "https://www.epicgames.com/id/login?redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fid%2Fapi%2Fredirect%3FclientId%3D3446cd72694c4a4485d81b77adbb2141%26responseType%3Dcode&prompt=login\nを開いて '{0}' にログインし、ログイン後に出てきたテキストを貼り付けてください",
         "confirm_authorization": "{0}\nを開いて '{1}' にログインし、'確認' ボタンを押してください",
         "account_incorrect": "このアカウント({0}) は '{1}' ではありません",
         "device_auth_error": "'{0}' のdevice_authが無効です。再起動して再度認証を行ってください",

--- a/modules/bot.py
+++ b/modules/bot.py
@@ -134,12 +134,14 @@ class Bot:
     def __init__(self, mode: str, loop: asyncio.AbstractEventLoop,
                  dev: Optional[bool] = False,
                  use_device_code: Optional[bool] = False,
-                 use_device_auth: Optional[bool] = False) -> None:
+                 use_device_auth: Optional[bool] = False,
+                 use_authorization_code: Optional[bool] = False) -> None:
         self.mode = mode
         self.loop = loop
         self.dev = dev
         self.use_device_code = use_device_code
         self.use_device_auth = use_device_auth
+        self.use_authorization_code = use_authorization_code
 
         self.clients = []
         self.updater = Updater(self)
@@ -2645,6 +2647,18 @@ class Bot:
 
                 return _session_id
 
+            def authorization_code(email):
+                async def _authorization_code():
+                    while True:
+                        text = self.l('authorization_code', email).get_text()
+                        self.web_text = text
+                        data = await ainput(f'{text}\n')
+                        match = re.search(r'[a-z0-9]{32}', data)
+                        if match is not None:
+                            return match.group()
+
+                return _authorization_code
+
             for num, config in enumerate(self.config['clients']):
                 refresh_token = refresh_tokens.get(config['fortnite']['email'].lower(), None)
                 device_auth_details = device_auths.get(config['fortnite']['email'].lower(), {})
@@ -2713,6 +2727,8 @@ class Bot:
                 auth = None
                 if self.use_device_auth and device_auth_details:
                     auth = fortnitepy.DeviceAuth(**device_auth_details)
+                elif self.use_device_auth and self.use_authorization_code:
+                    auth = fortnitepy.AuthorizationCodeAuth(authorization_code(config['fortnite']['email']))
                 if auth is None:
                     if self.use_device_code:
                         auth = MyAdvancedAuth(refresh_token)


### PR DESCRIPTION
Session ID auth is broken and there is no other way to authenticate. This should allow to use the `authorization_code` auth  with the `-use-authorization-code` parameter as long as you use it with `-use-device-auth`